### PR TITLE
Update `libevent` to version `2.1.12`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,8 @@ source:
   url: https://github.com/libevent/libevent/archive/release-{{ version }}-stable.tar.gz
   sha256: 7180a979aaa7000e1264da484f712d403fcf7679b1e9212c4e3d09f5c93efc24
   patches:
-    - 0374b55942e533a3c3997439481a8d05d6c8f729.patch
-    - 0001-Fix-destination-for-DLLs-lib-bin.patch
+    #- 0374b55942e533a3c3997439481a8d05d6c8f729.patch
+    #- 0001-Fix-destination-for-DLLs-lib-bin.patch
     - build-with-no-undefined.patch  # [osx and arm64]
 
 build:
@@ -25,6 +25,7 @@ requirements:
     - autoconf    # [unix]
     - automake    # [unix]
     - libtool     # [unix]
+    - patch       # [unix]
     - cmake       # [win]
     - m2-patch    # [win]
     - make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - patch       # [unix]
     - cmake       # [win]
     - m2-patch    # [win]
-    - make
+    - make        # [unix]
     - {{ compiler('c') }}
     - openssl
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.1.10" %}
+{% set version = "2.1.12" %}
 
 package:
   name: libevent
@@ -7,7 +7,7 @@ package:
 source:
   fn: libevent-{{ version }}.tar.gz
   url: https://github.com/libevent/libevent/archive/release-{{ version }}-stable.tar.gz
-  sha256: 52c9db0bc5b148f146192aa517db0762b2a5b3060ccc63b2c470982ec72b9a79
+  sha256: 7180a979aaa7000e1264da484f712d403fcf7679b1e9212c4e3d09f5c93efc24
   patches:
     - 0374b55942e533a3c3997439481a8d05d6c8f729.patch
     - 0001-Fix-destination-for-DLLs-lib-bin.patch


### PR DESCRIPTION
  `libevent` version `2.1.12`
1. check the upstream
    https://github.com/libevent/libevent/tree/release-2.1.12-stable

2. check the pinnings
    https://github.com/libevent/libevent/blob/release-2.1.12-stable/Vagrantfile
   
    https://github.com/libevent/libevent/blob/release-2.1.12-stable/Vagrantfile#L48

    https://github.com/libevent/libevent/blob/release-2.1.12-stable/Makefile.am

   https://github.com/libevent/libevent/blob/release-2.1.12-stable/CMakeLists.txt

3. check the changelogs
    https://github.com/libevent/libevent/blob/release-2.1.12-stable/ChangeLog

4. additional research
    https://github.com/conda-forge/libevent-feedstock/issues
    
    There are currently no issues mentioned in `conda-forge` at the time of the review

5. verify dev_url
    https://github.com/libevent/libevent
    
6. verify doc_url
    https://www.wangafu.net/~nickm/libevent-1.4/doxygen/html/
    (had to modify the doc_url to use `https` instead of `http`)

7. license is spdx compliant
    https://spdx.org/licenses/BSD-3-Clause.html

8. license family
    BSD
9. verify the build number
    (set the build number to zero)
10. verify setuptools
    setuptools does not seem to be required in the upstream
11. verify wheel
    wheel does not seem to be required in the upstream
12. pip in the test section
    pip does not seem to be a required in the upstream
13. veriy the test section
     python 2.7 seems to be required still in the upstream
     https://github.com/libevent/libevent/blob/release-2.1.12-stable/Vagrantfile#L48


Results:

- all-succeeded

Based on the research findings and the test results we can conclude
that it is safe to update `libevent` to version `2.1.12`
