### PR TITLE
Windows updates for v2.1.12

### DIFF
--- a/recipe/0001-Fix-destination-for-DLLs-lib-bin.patch
+++ b/recipe/0001-Fix-destination-for-DLLs-lib-bin.patch
@@ -1,7 +1,16 @@
 diff --git a/cmake/AddEventLibrary.cmake b/cmake/AddEventLibrary.cmake
-index 04f5837..8bca1f3 100644
+index 04f5837..88a19ca 100644
 --- a/cmake/AddEventLibrary.cmake
 +++ b/cmake/AddEventLibrary.cmake
+@@ -42,7 +42,7 @@ macro(export_install_target TYPE LIB_NAME OUTER_INCLUDES)
+         install(TARGETS "${LIB_NAME}_${TYPE}"
+             LIBRARY DESTINATION "lib" COMPONENT lib
+             ARCHIVE DESTINATION "lib" COMPONENT lib
+-            RUNTIME DESTINATION "lib" COMPONENT lib
++            RUNTIME DESTINATION "bin" COMPONENT lib
+             COMPONENT dev
+         )
+     else()
 @@ -69,7 +69,7 @@ macro(export_install_target TYPE LIB_NAME OUTER_INCLUDES)
              EXPORT LibeventTargets-${TYPE}
              LIBRARY DESTINATION "lib" COMPONENT lib

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,10 +1,19 @@
 :: Build
 mkdir build
 cd build
+
+@REM Link.exe is using the wrong zlib on win-32 because the regress test exe is the only item
+@REM that needs zlib. Therefore zlib is not listed in the host section of the requirements.
+@REM This exe is currently not a part of our test process, so skip compiling the those items.
+@REM If in the future we want to enable them, we will need to add zlib as a host requirement
+@REM only and ignore its run_exports since it is only a build / test time requirement.
+@REM https://github.com/libevent/libevent/blob/release-2.1.12-stable/CMakeLists.txt#L873-L883
+
 cmake -G "NMake Makefiles" ^
          -DCMAKE_BUILD_TYPE=Release ^
          -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
          -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+         -DEVENT__DISABLE_TESTS=ON ^
          %SRC_DIR%
 if errorlevel 1 exit 1
 


### PR DESCRIPTION
Updates for Windows builds of `libevent`:
+ Updated patch to include moving event.dll to the bin folder along with the other dlls.
+ Disabled compiling unused test exes that were causing build failures on **win-32**.